### PR TITLE
Fix specs so they pass when run all together or in isolation.

### DIFF
--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -6,7 +6,6 @@ describe ClientsController do
   before(:each) { sign_in admin }
 
   describe 'GET #index' do
-    Client.delete_all
     let!(:clients) { Array.new(3) { create(:client) } }
     it "populates an array of all clients" do
 

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "Admin Pages" do
+feature "Admin Pages", before_all_records: true do
 
   before(:all) { 30.times { create(:admin) } }
 

--- a/spec/features/clients_page_spec.rb
+++ b/spec/features/clients_page_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "Clients Page" do
+feature "Clients Page", before_all_records: true do
 
   let(:admin)  { create(:admin) }
   #Create  client to be first to click on, see the spec

--- a/spec/features/operations_page_spec.rb
+++ b/spec/features/operations_page_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature "Operations page" do
+feature "Operations page", before_all_records: true do
 
   let(:admin) { create(:admin) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,4 +75,8 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+
+  config.after(:all, before_all_records: true) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
 end


### PR DESCRIPTION
- Remove `Client.delete_all` form the `describe` block. This gets
  executed when the spec file is being loaded, which is long before
  the examples in the group are executed, and many specs can run
  in between these two times, so it doesn’t accomplish anything
  useful.
- Truncate the DB in an `after(:all)` hook in the contexts that
  use a `before(:all)` hook. Since that runs outside a transaction
  we need to clean up manually.
